### PR TITLE
Basically just a GH action to check the snap builds

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,0 +1,25 @@
+name: 🧪 Test snap can be built on x86_64
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: snapcore/action-build@v1
+        id: build
+
+      - uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'false'
+          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
+          plugs: ./plug-declaration.json
+#          slots: ./slot-declaration.json

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        node-version: [16.x]
+        
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -21,5 +21,5 @@ jobs:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
           # Plugs and Slots declarations to override default denial (requires store assertion to publish)
-          plugs: ./plug-declaration.json
+#          plugs: ./plug-declaration.json
 #          slots: ./slot-declaration.json

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ description: |
 # donation: "https://www.paypal.com/donate/?hosted_button_id=69NA8SXXFBDBN"
 license: Apache-2.0
 
-base: core20
+base: core22
 grade: stable
 confinement: strict
 
@@ -241,14 +241,17 @@ parts:
       - requirements_all.txt
     constraints:
       - homeassistant/package_constraints.txt
+    
     override-build: |
       CWD="$(pwd)"
       cd "${SNAPCRAFT_PART_BUILD}" && python3 -m script.translations develop --all && cd "${CWD}"
       snapcraftctl build
+    
     override-stage: |
       snapcraftctl stage
       find $SNAPCRAFT_STAGE/bin -type f -executable -exec sed -i 's/!\/usr\/bin\/env python3.11/!\/usr\/bin\/env python3/' {} \;
       sed -i 's/include-system-site-packages = false/include-system-site-packages = true/g' $SNAPCRAFT_STAGE/pyvenv.cfg
+        
   updater:
     after: [homeassistant]
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ description: |
 # donation: "https://www.paypal.com/donate/?hosted_button_id=69NA8SXXFBDBN"
 license: Apache-2.0
 
-base: core22
+base: core20
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
I was going to attempt bumping this to `core22` but that's not gonna happen this time around. I think the snap build and check may help with ensuring your builds are sane and pass snapcrafts checks, without having to any of it locally. 