### PR TITLE
Update to Home Assistant 2026.3.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: home-assistant-snap
 title: Home assistant
-version: '2026.2.3'
+version: '2026.3.1'
 icon: snap/gui/home-assistant-snap.svg
 summary: Open source home automation that puts local control and privacy first
 description: |


### PR DESCRIPTION
## 🏠 Home Assistant Update
This PR updates Home Assistant to version 2026.2.3.

### ✅ Build Status
The snap has been successfully built and tested in this workflow run.

Build artifacts are available in the workflow run artifacts
Snap review passed
### 📋 Changes
Updated version in snap/snapcraft.yaml to 2026.3.1
### 🔗 Links
[Home Assistant Release Notes](https://github.com/home-assistant/core/releases/tag/2026.3.1)